### PR TITLE
Add boolean 'sortable' attribute to fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import com.outr.lucene4s._
 
 ```scala
 val directory = Paths.get("index")
-val lucene = new Lucene(directory = Option(directory))
+val lucene = new DirectLucene(Nil, directory = Option(directory))
 ```
 
 NOTE: If you leave `directory` blank or set it to None (the default) it will use an in-memory index. 

--- a/src/main/scala/com/outr/lucene4s/DirectLucene.scala
+++ b/src/main/scala/com/outr/lucene4s/DirectLucene.scala
@@ -63,7 +63,7 @@ class DirectLucene(override val uniqueFields: List[String],
 
   private var listeners: List[LuceneListener] = Nil
 
-  override lazy val fullText: Field[String] = create.field[String]("fullText")
+  override lazy val fullText: Field[String] = create.field[String]("fullText", sortable = false)
 
   override def delete(term: SearchTerm): Unit = {
     indexWriter.deleteDocuments(term.toLucene(this))

--- a/src/main/scala/com/outr/lucene4s/LuceneCreate.scala
+++ b/src/main/scala/com/outr/lucene4s/LuceneCreate.scala
@@ -12,9 +12,10 @@ import scala.language.experimental.macros
 class LuceneCreate(val lucene: Lucene) {
   def field[T](name: String,
                fieldType: FieldType = FieldType.Stored,
-               fullTextSearchable: Boolean = lucene.defaultFullTextSearchable
+               fullTextSearchable: Boolean = lucene.defaultFullTextSearchable,
+               sortable: Boolean = true
               )(implicit support: ValueSupport[T], fv2SearchTerm: FieldAndValue[T] => SearchTerm): Field[T] = {
-    val field = new Field[T](name, fieldType, support, fullTextSearchable)
+    val field = new Field[T](name, fieldType, support, fullTextSearchable, sortable)
     lucene.synchronized {
       lucene._fields += field
     }

--- a/src/main/scala/com/outr/lucene4s/field/Field.scala
+++ b/src/main/scala/com/outr/lucene4s/field/Field.scala
@@ -7,7 +7,8 @@ import com.outr.lucene4s.query.SearchTerm
 case class Field[T](name: String,
                     fieldType: FieldType,
                     support: ValueSupport[T],
-                    fullTextSearchable: Boolean)
+                    fullTextSearchable: Boolean,
+                    sortable: Boolean = true)
                    (implicit val fv2SearchTerm: FieldAndValue[T] => SearchTerm) {
   def apply(value: T): FieldAndValue[T] = FieldAndValue[T](this, value)
 }

--- a/src/main/scala/com/outr/lucene4s/field/value/support/BooleanValueSupport.scala
+++ b/src/main/scala/com/outr/lucene4s/field/value/support/BooleanValueSupport.scala
@@ -11,10 +11,12 @@ object BooleanValueSupport extends ValueSupport[Boolean] {
     val v = if (value) 1 else 0
     val stored = new StoredField(field.name, v)
     val filtered = new IntPoint(field.name, v)
-    val sorted = new NumericDocValuesField(field.name, v)
     document.add(stored)
     document.add(filtered)
-    document.add(sorted)
+    if (field.sortable) {
+      val sorted = new NumericDocValuesField(field.name, v)
+      document.add(sorted)
+    }
   }
 
   override def fromLucene(field: IndexableField): Boolean = if (field.numericValue().intValue() == 1) true else false

--- a/src/main/scala/com/outr/lucene4s/field/value/support/DoubleValueSupport.scala
+++ b/src/main/scala/com/outr/lucene4s/field/value/support/DoubleValueSupport.scala
@@ -10,10 +10,12 @@ object DoubleValueSupport extends ValueSupport[Double] {
   override def write(field: Field[Double], value: Double, document: Document): Unit = {
     val stored = new StoredField(field.name, value)
     val filtered = new DoublePoint(field.name, value)
-    val sorted = new DoubleDocValuesField(field.name, value)
     document.add(stored)
     document.add(filtered)
-    document.add(sorted)
+    if (field.sortable) {
+      val sorted = new DoubleDocValuesField(field.name, value)
+      document.add(sorted)
+    }
   }
 
   override def fromLucene(field: IndexableField): Double = field.numericValue().doubleValue()

--- a/src/main/scala/com/outr/lucene4s/field/value/support/IntValueSupport.scala
+++ b/src/main/scala/com/outr/lucene4s/field/value/support/IntValueSupport.scala
@@ -10,10 +10,12 @@ object IntValueSupport extends ValueSupport[Int] {
   override def write(field: Field[Int], value: Int, document: Document): Unit = {
     val stored = new StoredField(field.name, value)
     val filtered = new IntPoint(field.name, value)
-    val sorted = new NumericDocValuesField(field.name, value)
     document.add(stored)
     document.add(filtered)
-    document.add(sorted)
+    if (field.sortable) {
+      val sorted = new NumericDocValuesField(field.name, value)
+      document.add(sorted)
+    }
   }
 
   override def fromLucene(field: IndexableField): Int = field.numericValue().intValue()

--- a/src/main/scala/com/outr/lucene4s/field/value/support/LongValueSupport.scala
+++ b/src/main/scala/com/outr/lucene4s/field/value/support/LongValueSupport.scala
@@ -10,10 +10,12 @@ object LongValueSupport extends ValueSupport[Long] {
   override def write(field: Field[Long], value: Long, document: Document): Unit = {
     val stored = new StoredField(field.name, value)
     val filtered = new LongPoint(field.name, value)
-    val sorted = new NumericDocValuesField(field.name, value)
     document.add(stored)
     document.add(filtered)
-    document.add(sorted)
+    if (field.sortable) {
+      val sorted = new NumericDocValuesField(field.name, value)
+      document.add(sorted)
+    }
   }
 
   override def fromLucene(field: IndexableField): Long = field.numericValue().longValue()

--- a/src/main/scala/com/outr/lucene4s/field/value/support/SpatialPointValueSupport.scala
+++ b/src/main/scala/com/outr/lucene4s/field/value/support/SpatialPointValueSupport.scala
@@ -11,10 +11,12 @@ object SpatialPointValueSupport extends ValueSupport[SpatialPoint] {
   override def write(field: Field[SpatialPoint], value: SpatialPoint, document: Document): Unit = {
     val stored = new StoredField(field.name, value.toString)
     val filtered = new LatLonPoint(field.name, value.latitude, value.longitude)
-    val sorted = new LatLonDocValuesField(field.name, value.latitude, value.longitude)
     document.add(stored)
     document.add(filtered)
-    document.add(sorted)
+    if (field.sortable) {
+      val sorted = new LatLonDocValuesField(field.name, value.latitude, value.longitude)
+      document.add(sorted)
+    }
   }
 
   override def fromLucene(field: IndexableField): SpatialPoint = SpatialPoint.fromString(field.stringValue())

--- a/src/main/scala/com/outr/lucene4s/field/value/support/StringValueSupport.scala
+++ b/src/main/scala/com/outr/lucene4s/field/value/support/StringValueSupport.scala
@@ -14,8 +14,9 @@ object StringValueSupport extends ValueSupport[String] {
     if (field.sortable) {
       val bytes = new BytesRef(value)
       if (bytes.length > ByteBlockPool.BYTE_BLOCK_SIZE - 2)
-        System.err.println(s"Value for field ${field.name} is greater than ${ByteBlockPool.BYTE_BLOCK_SIZE - 2}. " +
-          "This will cause an error. Reduce field size or set: sortable = false")
+        throw new RuntimeException(s"Value for field ${field.name} is greater than " +
+          s"${ByteBlockPool.BYTE_BLOCK_SIZE - 2} bytes. " +
+          "This would cause a Lucene error. Reduce field size or set: sortable = false")
       val sorted = new SortedDocValuesField(field.name, bytes)
       document.add(sorted)
     }


### PR DESCRIPTION
Very rarely would you want to sort on very long fields. 
This lets you disable sorting and save index space by not storing the DocValue for a field. 
Workaround for #10